### PR TITLE
Secure websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can find a sample configuration file for Apache2 beneath the [apache2](apach
 
 ## WSS options
 
-If you want to setup an encrypted remote endpoint (using apache mod_ssl, for example) you can use the client option `-tls` to connect to a secure websocket (**wss**).
+If you want to setup an encrypted remote endpoint (using apache mod_ssl, for example) you can use the `wss://` prefix to connect to a secure websocket (eg. `-tunnel wss://tunneller.example.com`). If no prefix is set on the `-tunnel` option `ws://` is assumed.
 
 In case the SSL certificate you have installed on your webserver is self-signed or you are just testing, you can use the `-insecure` option to allow connection to unverified domains.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ If you wish to host your own central-server things are a little more complex:
 
 You can find a sample configuration file for Apache2 beneath the [apache2](apache2) directory.
 
+## WSS options
 
+If you want to setup an encrypted remote endpoint (using apache mod_ssl, for example) you can use the client option `-tls` to connect to a secure websocket (**wss**).
+
+In case the SSL certificate you have installed on your webserver is self-signed or you are just testing, you can use the `-insecure` option to allow connection to unverified domains.
+
+See the [apache2](apache2) folder for documentation on how to setup an encrypted websocket.
 
 ## Github Setup
 

--- a/apache2/README.md
+++ b/apache2/README.md
@@ -63,6 +63,35 @@ production:
         ProxyBadHeader ignore
     </VirtualHost>
 
+## Encrypted websocket tunnel
+
+If you want to use a TLS encrypted tunnel just change the configuration to listen on 443 and 
+mod_ssl as usual:
+
+
+    #
+    # This is the bare-tunnel domain.
+    #
+    # Accesses to this will be websockets, so we need to handle
+    # that by using `wss:/`
+    #
+    <VirtualHost 176.9.183.100:443>
+        ServerName tunneller.steve.fi
+        
+        SSLEngine on
+        SSLCertificateFile      /path/to/your/certificate.pem
+        SSLCertificateKeyFile   /path/to/your/key.pem
+        SSLCertificateChainFile /path/to/your/chain.pem
+
+        RewriteEngine On
+        RewriteCond %{HTTP:Upgrade} =websocket [NC]
+        RewriteRule /(.*)           ws://localhost:8080/$1 [P,L]
+        RewriteCond %{HTTP:Upgrade} !=websocket [NC]
+        RewriteRule /(.*)           http://localhost:8080/$1 [P,L]
+        [...]
+        # Same VirtualHost configuration as example above
+
+Obviously you can encrypt also the public (*.tunneller.steve.fi) part with using HTTPS
 
 ## Modules
 


### PR DESCRIPTION
This is a very simple PR to allow client connections to secure websockets (wss).
Two boolean flags has been added, one (`-tls`) to change the protocol schema from `ws` to `wss` and one that allows insecure connections (`-insecure`) to unverified SSL certificates.

Some documentation about has been added too.