### PR TITLE
Allow client/server to use a different MQ port.

### DIFF
--- a/cmd_client.go
+++ b/cmd_client.go
@@ -70,6 +70,10 @@ type clientCmd struct {
 	// The recent requests we've seen.
 	//
 	requests []Request
+
+	//
+	// The port to connect to MQ with
+	mqPort int
 }
 
 // Name returns the name of this sub-command.
@@ -91,6 +95,7 @@ func (p *clientCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.expose, "expose", "", "The host/port to expose to the internet.")
 	f.StringVar(&p.tunnel, "tunnel", "tunnel.steve.fi", "The address of the publicly visible tunnel-host")
 	f.StringVar(&p.name, "name", "", "The name for this connection")
+	f.IntVar(&p.mqPort, "mq-port", 1883, "The MQ port")
 }
 
 // onMessage is called when a message is received upon the MQ-topic we're
@@ -270,7 +275,7 @@ func (p *clientCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	//
 	// Setup the server-address.
 	//
-	opts := MQTT.NewClientOptions().AddBroker(fmt.Sprintf("tcp://%s:1883", p.tunnel))
+	opts := MQTT.NewClientOptions().AddBroker(fmt.Sprintf("tcp://%s:%d", p.tunnel, p.mqPort))
 
 	//
 	// Set our name.

--- a/cmd_server.go
+++ b/cmd_server.go
@@ -43,6 +43,9 @@ type serveCmd struct {
 
 	// the port we bind upon
 	bindPort int
+
+	// The port MQ listens upon
+	mqPort int
 }
 
 // Name returns the name of this sub-command.
@@ -61,6 +64,7 @@ func (p *serveCmd) Usage() string {
 // SetFlags configures the flags this sub-command accepts.
 func (p *serveCmd) SetFlags(f *flag.FlagSet) {
 	f.IntVar(&p.bindPort, "port", 8080, "The port to bind upon.")
+	f.IntVar(&p.mqPort, "mq-port", 1883, "The MQ port.")
 	f.StringVar(&p.bindHost, "host", "127.0.0.1", "The IP to listen upon.")
 }
 
@@ -294,7 +298,10 @@ func (p *serveCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 	//
 	// Connect to our MQ instance.
 	//
-	opts := MQTT.NewClientOptions().AddBroker("tcp://localhost:1883")
+	mq := fmt.Sprintf("tcp://localhost:%d", p.mqPort)
+	fmt.Printf("Connecting to MQ %s\n", mq)
+
+	opts := MQTT.NewClientOptions().AddBroker(mq)
 	p.mq = MQTT.NewClient(opts)
 	if token := p.mq.Connect(); token.Wait() && token.Error() != nil {
 		fmt.Printf("Failed to connect to MQ-server: %s\n", token.Error())


### PR DESCRIPTION
This closes #10.